### PR TITLE
Add options for nodeBin, requires and env

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,13 @@ node_js:
 - 4
 - 6
 
+before_install:
+- curl -o- -L https://yarnpkg.com/install.sh | bash
+- export PATH=$HOME/.yarn/bin:$PATH
+
 install:
-- npm install
+- yarn install
 
 script:
-- npm run lint
-- npm run test
+- yarn run lint
+- yarn run test

--- a/README.md
+++ b/README.md
@@ -42,7 +42,15 @@ Promise.all([
 
 Arguments and return values are passed between node processes using NodeJs's [child process IPC](https://nodejs.org/api/process.html#process_process_send_message_sendhandle_options_callback) channel and the [dnode protocol](https://github.com/substack/dnode-protocol). This means all objects will be JSON stringified and parsed. Rejected Error objects will be converted back into error objects with their message, stack traces and all iterable properties preserved. The dnode protocol allows for circular references and callback functions. (Functions who's return value isn't needed.)
 
-### Todo
+## API
+
+- `childProcessRequire(path, [opts])` returns a function that takes any arguments and passes them to the default export or `module.export` of file at the `path`. Returns a promise that resolves to the return of the remote function
+- `opts.nodeBin` optional binary to run for nodejs, defaults to `process.argv[0]`. This is a perfect place to specify the binary for an alternate version of node. When [this issue](https://github.com/babel/babel/issues/4554#issuecomment-290958986) closes you'll be able to use `babel-node` here but for now it doesn't work.
+- `opts.requires` An array of strings of package names to require before requiring your function's file. This is the perect place for `babel-register`.
+- `opts.env` An object of env vars to copy into the child process's copy of `process.env`
+
+
+## Todo
 - Better API docs
 - Expose `execa`'s options including timeouts
 - Test to see if alternative nodejs runtimes work (etc, `babel-node`)

--- a/lib/child-exec.js
+++ b/lib/child-exec.js
@@ -3,6 +3,15 @@
 const debug = require('debug')('cpr:child-exec')
 const dnodeProto = require('dnode-protocol')
 
+// For babel-node export default syntax
+function requireWithDefault (obj) {
+  if (typeof obj === 'object' && typeof obj.default === 'function') {
+    debug('default export detected')
+    return obj.default
+  }
+  return obj
+}
+
 function wrapError (data) {
   if (!(data instanceof Error)) {
     return { data }
@@ -15,16 +24,33 @@ function wrapError (data) {
   return { error }
 }
 
+if (!process.send) {
+  throw new Error('"process.send" is not available, cannot communicate via nodejs IPC')
+}
+
 const childScript = process.argv[2]
-debug('started, setting up to execute', childScript)
-let func
+if (!childScript) {
+  throw new Error('No childScript specified')
+}
+
+debug('started', process.argv.join(', '))
+
+// Require packages
+const pkgs = process.argv[3].split(',')
+pkgs.forEach(pkg => {
+  if (!pkg) { return }
+  debug('pre-requiring', pkg)
+  require(pkg)
+})
+
+// Setup dnode over ipc
+let func // this can't be set until after we're connected
 const proto = dnodeProto({
   func: function () {
     debug('recieving arguments')
     func.apply(null, arguments)
   }
 })
-
 process.on('message', args => proto.handle(args))
 proto.on('request', req => process.send(req))
 
@@ -36,7 +62,7 @@ proto.on('remote', function (remote) {
     let childFunction
     try {
       debug('Requiring', childScript)
-      childFunction = require(childScript)
+      childFunction = requireWithDefault(require(childScript))
     } catch (error) {
       reject(error)
       process.exit(1)

--- a/lib/index.js
+++ b/lib/index.js
@@ -57,13 +57,23 @@ function controlProcess (child, args) {
   })
 }
 
-module.exports = function childProcessRequire (childScript) {
-  const nodeBin = process.argv[0]
-  const args = [childExecScript, childScript]
-  const options = { stdio: ['inherit', 'inherit', 'inherit', 'ipc'] }
-  debug(`Starting child with`, childScript)
+module.exports = function childProcessRequire (childScript, opts) {
+  opts = Object.assign({
+    nodeBin: process.argv[0],
+    requires: [],
+    env: {}
+  }, opts)
+  const requires = opts.requires.join(',')
+  const args = [childExecScript, childScript, requires]
+  debug('opts.env', opts.env)
+  const env = Object.assign({}, process.env, opts.env)
+  const execOptions = {
+    env,
+    stdio: ['inherit', 'inherit', 'inherit', 'ipc']
+  }
+  debug(`Starting child with`, opts.nodeBin, args.join(', '))
   return function () {
     const funcArgs = [].slice.apply(arguments)
-    return controlProcess(execa(nodeBin, args, options), funcArgs)
+    return controlProcess(execa(opts.nodeBin, args, execOptions), funcArgs)
   }
 }

--- a/package.json
+++ b/package.json
@@ -22,6 +22,9 @@
     "execa": "^0.6.3"
   },
   "devDependencies": {
+    "babel-cli": "^6.24.0",
+    "babel-preset-env": "^1.3.2",
+    "babel-register": "^6.24.0",
     "chai": "^3.5.0",
     "debug": "^2.6.3",
     "eslint": "^3.19.0",
@@ -40,5 +43,17 @@
       "expect": false,
       "assert": false
     }
+  },
+  "babel": {
+    "presets": [
+      [
+        "env",
+        {
+          "targets": {
+            "node": 4
+          }
+        }
+      ]
+    ]
   }
 }

--- a/test/scripts/babel-node.js
+++ b/test/scripts/babel-node.js
@@ -1,0 +1,3 @@
+export default function () {
+  return 'Success!'
+}

--- a/test/scripts/test-env-2.js
+++ b/test/scripts/test-env-2.js
@@ -1,0 +1,5 @@
+module.exports = function () {
+  const testEnv = process.env.testEnv
+  const testEnv2 = process.env.testEnv2
+  return Promise.resolve({ testEnv, testEnv2 })
+}


### PR DESCRIPTION
We can now support babel via `requires`.